### PR TITLE
clickbench: Add Profile label

### DIFF
--- a/axiom/run.go
+++ b/axiom/run.go
@@ -38,7 +38,7 @@ func runCmd() command {
 	failfast := fs.Bool("failfast", false, "Exit on first error")
 	noCache := fs.Bool("no-cache", true, "Do not use axiom results caching")
 	version := fs.String("version", firstNonZero(gitSha(), "dev"), "Version of the benchmarking client code")
-	label := fs.String("label", os.Getenv("AXIOM_TOKEN"), "Axiom auth token [defaults to $AXIOM_TOKEN]")
+	label := fs.String("label", os.Getenv("AXIOM_LABEL"), "Profile label [defaults to $AXIOM_LABEL]")
 
 	return command{fs, func(args []string) error {
 		fs.Parse(args)

--- a/axiom/run.go
+++ b/axiom/run.go
@@ -134,6 +134,10 @@ func newAxiomClient(cli *http.Client, version, apiURL, org, token, traceURL, lab
 		return nil, fmt.Errorf("error parsing url: %w", err)
 	}
 
+	if label == "" {
+		label = "clickbench" // default profile label if not set
+	}
+
 	return &axiomClient{
 		cli:      cli,
 		apiURL:   parsedAPIURL,
@@ -203,10 +207,6 @@ func (c *axiomClient) do(ctx context.Context, rawURL string, id int, body, v any
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", "axiom-clickbench/"+c.version)
 	req.Header.Set("X-Axiom-Org-Id", c.org)
-
-	if c.label == "" {
-		c.label = "clickbench" // default profile label if not set
-	}
 
 	if id >= 0 {
 		req.Header.Set("X-Axiom-Profile-Label", fmt.Sprintf("%s-%d", c.label, id))

--- a/axiom/run.go
+++ b/axiom/run.go
@@ -42,11 +42,11 @@ func runCmd() command {
 
 	return command{fs, func(args []string) error {
 		fs.Parse(args)
-		return run(*version, *apiURL, *traceURL, *org, *token, *iters, *failfast, *noCache, *label)
+		return run(*version, *apiURL, *traceURL, *org, *token, *label, *iters, *failfast, *noCache)
 	}}
 }
 
-func run(version, apiURL, traceURL, org, token string, iters int, failfast, noCache bool, label string) error {
+func run(version, apiURL, traceURL, org, token, label string, iters int, failfast, noCache bool) error {
 	if apiURL == "" {
 		return fmt.Errorf("api-url cannot be empty")
 	}

--- a/axiom/run.go
+++ b/axiom/run.go
@@ -38,7 +38,7 @@ func runCmd() command {
 	failfast := fs.Bool("failfast", false, "Exit on first error")
 	noCache := fs.Bool("no-cache", true, "Do not use axiom results caching")
 	version := fs.String("version", firstNonZero(gitSha(), "dev"), "Version of the benchmarking client code")
-	label := fs.String("label", os.Getenv("AXIOM_LABEL"), "Profile label [defaults to $AXIOM_LABEL]")
+	label := fs.String("label", "", "Profile label")
 
 	return command{fs, func(args []string) error {
 		fs.Parse(args)


### PR DESCRIPTION
Added a profile label parameter, so we can differentiate between Metricsbench and Clickbench.

We default to Clickbench if no parameter is present.